### PR TITLE
fix: tqdm 객체를 하나씩 생성되도록 수정

### DIFF
--- a/project/local_to_gcp_storage_v2/thread/file_worker.py
+++ b/project/local_to_gcp_storage_v2/thread/file_worker.py
@@ -55,58 +55,47 @@ class Worker:
         return mimetypes.guess_type(source_url)[0]
 
 
-    @pbar_manager
     def delete_storage_files(self, thread_idx, file_list: List[str], pbar: tqdm):
-        pbar.write(f"{thread_idx} DELETE STORAGE START(total : {len(file_list)})")
-        for del_f_path in pbar:
+        for del_f_path in file_list:
             blob_name = f"{self.storage_base_path}/{del_f_path}"
             blob = self.bucket.get_blob(blob_name)
-            pbar.set_description(f"{thread_idx} DELETING {blob_name}")
             blob.delete()
-        pbar.write(f"{thread_idx} DELETE STORAGE DONE(total : {len(file_list)})")
+            pbar.update(1)
+            pbar.write(f"{thread_idx} Thread Delete Done, {blob_name}")
     
-    @pbar_manager
     def upload_files(self, thread_idx, file_list: List[str], pbar: tqdm):
-        pbar.write(f"{thread_idx} UPLOAD START(total : {len(file_list)})")
-        for upload_f_path in pbar:
+        for upload_f_path in file_list:
             blob_name = f"{self.storage_base_path}/{upload_f_path}"
             mime = self._get_content_type(upload_f_path)
             local_full_path = f"{self.local_base_path}/{upload_f_path}"
             blob = self.bucket.blob(blob_name)
             CACHE_CONTROL = "no-store"
             blob.cache_control = CACHE_CONTROL
-            pbar.set_description(f"{thread_idx} UPLOADING {local_full_path}")
             with open(local_full_path, "rb") as f:
                 blob.upload_from_file(f, content_type=mime)
+            pbar.update(1)
+            pbar.write(f"{thread_idx} Thread Upload Done, {local_full_path}")
             
-        pbar.write(f"{thread_idx} UPLOAD DONE(total : {len(file_list)})")
-            
-
-    @pbar_manager
     def download_files(self, thread_idx, file_list: List[str], pbar: tqdm):
         storage_base_path = self.storage_base_path
         local_base_path = self.local_base_path
-        pbar.write(f"{thread_idx} DOWNLOAD START(total : {len(file_list)})")
-        for download_f_path in pbar:
+        for download_f_path in file_list:
             local_full_path = f"{local_base_path}/{download_f_path}"
             blob_name = f"{storage_base_path}/{download_f_path}"
             blob = self.bucket.blob(blob_name)
-            pbar.set_description(f"{thread_idx} DOWNLOADING {blob_name}")
             with open(local_full_path, "wb") as f:
                 self.client.download_blob_to_file(blob, f)
-        
-        pbar.write(f"{thread_idx} DOWNLOAD DONE(total : {len(file_list)})")
+            pbar.update(1)
+            pbar.write(f"{thread_idx} Thread Download Done, {local_full_path}")
 
-    @pbar_manager
     def delete_local_files(self, thread_idx, file_list: List[str], pbar: tqdm):
         base_path = self.local_base_path
-        pbar.write(f"{thread_idx} DELETE LOCAL START(total : {len(file_list)})")
-        for del_f_path in pbar:
+        for del_f_path in file_list:
             full_path = f"{base_path}/{del_f_path}"
-            pbar.set_description(f"{thread_idx} DELETING {full_path}")
             if(os.path.exists(full_path) and os.path.isfile(full_path)):
                 os.remove(full_path)
-        pbar.write(f"{thread_idx} DELETE LOCAL DONE(total : {len(file_list)})")
+            pbar.update(1)
+            pbar.write(f"{thread_idx} Thread Delete Done, {full_path}")
 
 
     def _get_local_file_list(self, target: str, file_list: List[str]) -> List[str]:

--- a/project/local_to_gcp_storage_v2/thread/main.py
+++ b/project/local_to_gcp_storage_v2/thread/main.py
@@ -42,4 +42,4 @@ if(__name__ == "__main__"):
     start = time.time()
     syncer = Sync(args.focus, args.target, args.ignore, args.overwrite)
     syncer.sync()
-    print(f"sync done ...\nrunning time : {round((time.time() - start), 2)}")
+    print(f"Sync done ...\nrunning time : {round((time.time() - start), 2)} sec")


### PR DESCRIPTION
tqdm 사용 방식 변경

thread마다 하나의 tqdm객체 대신 생성 리스트, 삭제 리스트 2개의 tqdm 객체를 사용하여
진행상황 출력하도록 변경